### PR TITLE
Prevent plugin from running on poetry "self" commands

### DIFF
--- a/src/poetry_pre_commit_plugin/plugin.py
+++ b/src/poetry_pre_commit_plugin/plugin.py
@@ -54,7 +54,7 @@ class PreCommitPlugin(ApplicationPlugin):  # type: ignore
         if command.option("dry-run") is True:
             return
 
-        self._install_pre_commit_hooks(event.io)
+        self._install_pre_commit_hooks(io)
 
     def _install_pre_commit_hooks(self, io: IO) -> None:
         try:


### PR DESCRIPTION
Closes #1 

I went ahead and added some changes to cope with `self` commands. So commands like `poetry self add keyring` for instance do not trigger installation of the hooks.

The type of event passed to the callback function was also changed to the proper one when listening for `TERMINATE` type events. This removes the access to the "private" `_exit_code`. 

The changes were tested on my machine.

