### PR TITLE
Added post-checkout and post-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ the plugin will check the following conditions:
 1. Is the project inside a git repository?
 2. Is `pre-commit` listed as a dependency of the project (or, in the case of
    `poetry add` - was it just added)?
-3. Has the pre-commit hook **not** been activated yet (i.e. the file
-   `.git/hooks/pre-commit` does not exist)?
+3. Has the git hook have **not** been activated yet (i.e. the file
+   `.git/hooks/pre-commit`, `.git/hooks/post-checkout` or `.git/hooks/post-merge`
+   does not exist)?
 
-If all conditions are met, the plugin will run `pre-commit install` for you.
+If all conditions are met, the plugin will run `pre-commit install --install-hooks -t post-checkout -t post-merge -t pre-commit` for you.

--- a/src/poetry_pre_commit_plugin/plugin.py
+++ b/src/poetry_pre_commit_plugin/plugin.py
@@ -60,7 +60,7 @@ class PreCommitPlugin(ApplicationPlugin):  # type: ignore
         try:
             io.write_line("<info>Installing pre-commit hooks...</>")
             return_code = subprocess.check_call(
-                ["poetry", "run", "pre-commit", "install",],
+                ["poetry", "run", "pre-commit", "install", "--install-hooks", "-t", "post-checkout", "-t", "post-merge", "-t", "pre-commit"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )

--- a/src/poetry_pre_commit_plugin/plugin.py
+++ b/src/poetry_pre_commit_plugin/plugin.py
@@ -60,7 +60,7 @@ class PreCommitPlugin(ApplicationPlugin):  # type: ignore
         try:
             io.write_line("<info>Installing pre-commit hooks...</>")
             return_code = subprocess.check_call(
-                ["poetry", "run", "pre-commit", "install"],
+                ["poetry", "run", "pre-commit", "install",],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )


### PR DESCRIPTION
Since poetry 1.7 a post-checkout and post-merge git-hook was added to poetry.
This PR allows the installation of those hooks via this plugin when using poetry install.