### PR TITLE
Revert back to standard dependency version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "poetry_pre_commit_plugin", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-poetry = "^2.0.0"
+poetry = ">=1.0.0,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
Rewrote the poetry version requirement

Using the caret ^ for versioning means that the plugins requires poetry >=2.0.0,<3.0.0. This means that one cannot simply upgrade the plugin then update poetry when coming from poetry 1.8.3. 

The plugin needs to be removed and reinstalled once poetry is updated. 

This correction makes it easier. Upgrade the plugin `poetry self add poetry-pre-...@latest` and then update poetry `poetry self update`

It also does not break the compatibility continuity of the plugin.